### PR TITLE
fix: incorrect hash in staging queue

### DIFF
--- a/sync/src/p2p/mod.rs
+++ b/sync/src/p2p/mod.rs
@@ -126,7 +126,7 @@ impl P2pMgr {
                     socket
                         .set_recv_buffer_size(1 << 24)
                         .expect("set_recv_buffer_size failed");
-                    
+
                     socket
                         .set_keepalive(Some(Duration::from_secs(30)))
                         .expect("set_keepalive failed");

--- a/sync/src/sync/handler/blocks_bodies_handler.rs
+++ b/sync/src/sync/handler/blocks_bodies_handler.rs
@@ -196,19 +196,19 @@ impl BlockBodiesHandler {
                             if node.mode == Mode::LIGHTNING {
                                 let mut block_hashes_to_stage = Vec::new();
                                 let mut blocks_to_stage = Vec::new();
-                                if let Some(parent) = blocks.get(0) {
-                                    let parent_hash = parent.header.hash();
-                                    let parent_number = parent.header.number();
+                                if let Some(block) = blocks.get(0) {
+                                    let parent_hash = block.header.parent_hash();
+                                    let parent_number = block.header.number() - 1;
                                     if let Ok(mut staged_blocks) =
                                         SyncStorage::get_staged_blocks().lock()
                                     {
                                         if staged_blocks.len() < 32
                                             && !staged_blocks.contains_key(&parent_hash)
                                         {
-                                            for block in blocks.iter() {
-                                                let hash = block.header.hash();
+                                            for blk in blocks.iter() {
+                                                let hash = blk.header.hash();
                                                 block_hashes_to_stage.push(hash);
-                                                blocks_to_stage.push(block.rlp_bytes(Seal::With));
+                                                blocks_to_stage.push(blk.rlp_bytes(Seal::With));
                                             }
 
                                             let max_staged_block_number =
@@ -221,7 +221,7 @@ impl BlockBodiesHandler {
                                                 block_hashes_to_stage,
                                             );
 
-                                            staged_blocks.insert(parent_hash, blocks_to_stage);
+                                            staged_blocks.insert(*parent_hash, blocks_to_stage);
 
                                             if max_staged_block_number
                                                 > SyncStorage::get_max_staged_block_number()

--- a/sync/src/sync/mod.rs
+++ b/sync/src/sync/mod.rs
@@ -480,7 +480,7 @@ impl ChainNotify for Sync {
             let mut max_imported_block_number = 0;
             let client = SyncStorage::get_block_chain();
             for hash in imported.iter() {
-                ImportHandler::import_staged_blocks(&hash);
+                // ImportHandler::import_staged_blocks(&hash);
                 let block_id = BlockId::Hash(*hash);
                 if client.block_status(block_id) == BlockStatus::InChain {
                     if let Some(block_number) = client.block_number(block_id) {


### PR DESCRIPTION
use parent hash as key when searching staged blocks